### PR TITLE
update to pandoc 2 and use R 3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.5.1
+FROM rocker/r-ver:3.5.2
 
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libxml2-dev \ 
@@ -8,9 +8,9 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   subversion \
   git \
   zlib1g-dev \
-  && wget -q https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb \
-  && dpkg -i pandoc-1.19.2.1-1-amd64.deb \
-  && rm pandoc-1.19.2.1-1-amd64.deb \
+  && wget -q https://github.com/jgm/pandoc/releases/download/2.5/pandoc-2.5-1-amd64.deb \
+  && dpkg -i pandoc-2.5-1-amd64.deb \
+  && rm pandoc-2.5-1-amd64.deb \
   && . /etc/environment \
   && install2.r --error \
     --repos 'http://www.bioconductor.org/packages/release/bioc' \


### PR DESCRIPTION
According to Yihui Xie we can/should use pandoc 2, so let's test with that now.

https://yihui.name/en/2018/06/time-for-pandoc-2-x/