### PR TITLE
4.1.2

### DIFF
--- a/.github/workflows/dh-buildr.yml
+++ b/.github/workflows/dh-buildr.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr and publish to Docker Hub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr-tidyverse and publish to Docker Hub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -44,7 +44,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr-reticulate and publish to Docker Hub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -60,7 +60,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr-rmd and publish to Docker Hub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/dh-buildr.yml
+++ b/.github/workflows/dh-buildr.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr and publish to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr-tidyverse and publish to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -44,7 +44,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr-reticulate and publish to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -60,7 +60,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build buildr-rmd and publish to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+.vscode/

--- a/buildr-reticulate/Dockerfile
+++ b/buildr-reticulate/Dockerfile
@@ -1,4 +1,4 @@
-FROM mangothecat/buildr-tidyverse:4.0.3
+FROM mangothecat/buildr-tidyverse:4.1.2
 
 # Python (3), and virtualenv
 RUN apt-get update -qq \
@@ -12,7 +12,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git
 
-RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2020.02-Linux-x86_64.sh -O ~/anaconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_64.sh -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \

--- a/buildr-reticulate/Dockerfile
+++ b/buildr-reticulate/Dockerfile
@@ -22,7 +22,7 @@ RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2021.11-Linux-x86_6
 # reticulate R package
 RUN . /etc/environment \
     && install2.r --error \
-      --repos 'https://cloud.r-project.org' \
-      --repos 'http://www.bioconductor.org/packages/release/bioc' \
-      --repos $MRAN \
+      #--repos 'https://cloud.r-project.org' \
+      #--repos 'http://www.bioconductor.org/packages/release/bioc' \
+      #--repos $MRAN \
 	  reticulate

--- a/buildr-rmd/Dockerfile
+++ b/buildr-rmd/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update -qq \
 # R package dependencies
 RUN . /etc/environment \
     && install2.r --error \
-      --repos 'https://cloud.r-project.org' \
-      --repos 'http://www.bioconductor.org/packages/release/bioc' \
-      --repos $MRAN \
+      #--repos 'https://cloud.r-project.org' \
+      #--repos 'http://www.bioconductor.org/packages/release/bioc' \
+      #--repos $MRAN \
 	  devtools \
 	  roxygen2 \
 	  knitr \

--- a/buildr-rmd/Dockerfile
+++ b/buildr-rmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM mangothecat/buildr-reticulate:4.0.3
+FROM mangothecat/buildr-reticulate:4.1.2
 
 # Debian chromium appears to be too old
 RUN apt-get update -qq \

--- a/buildr-tidyverse/Dockerfile
+++ b/buildr-tidyverse/Dockerfile
@@ -1,4 +1,4 @@
-FROM mangothecat/buildr:4.0.3
+FROM mangothecat/buildr:4.l.2
 
 RUN . /etc/environment \
   && install2.r --error \

--- a/buildr-tidyverse/Dockerfile
+++ b/buildr-tidyverse/Dockerfile
@@ -2,8 +2,8 @@ FROM mangothecat/buildr:4.1.2
 
 RUN . /etc/environment \
   && install2.r --error \
-    --repos 'https://cloud.r-project.org' \
-    --repos 'http://www.bioconductor.org/packages/release/bioc' \
-    --repos $MRAN \
+    #--repos 'https://cloud.r-project.org' \
+    #--repos 'http://www.bioconductor.org/packages/release/bioc' \
+    #--repos $MRAN \
     tidyverse \
     testthat

--- a/buildr-tidyverse/Dockerfile
+++ b/buildr-tidyverse/Dockerfile
@@ -1,4 +1,4 @@
-FROM mangothecat/buildr:4.l.2
+FROM mangothecat/buildr:4.1.2
 
 RUN . /etc/environment \
   && install2.r --error \

--- a/buildr/Dockerfile
+++ b/buildr/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   && rm pandoc-2.17.0.1-1-amd64.deb \
   && . /etc/environment \
   && install2.r --error \
-    --repos 'https://cloud.r-project.org' \
-    --repos 'http://www.bioconductor.org/packages/release/bioc' \
-    --repos $MRAN \
+    #--repos 'https://cloud.r-project.org' \
+    #--repos 'http://www.bioconductor.org/packages/release/bioc' \
+    #--repos $MRAN \
     remotes
 
 COPY build.sh /home/docker/

--- a/buildr/Dockerfile
+++ b/buildr/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.0.3
+FROM rocker/r-ver:4.1.2
 
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libxml2-dev \
@@ -8,9 +8,9 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   subversion \
   git \
   zlib1g-dev \
-  && wget -q https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-1-amd64.deb \
-  && dpkg -i pandoc-2.7.3-1-amd64.deb \
-  && rm pandoc-2.7.3-1-amd64.deb \
+  && wget -q https://github.com/jgm/pandoc/releases/download/2.17.0.1/pandoc-2.17.0.1-1-amd64.deb \
+  && dpkg -i pandoc-2.17.0.1-1-amd64.deb \
+  && rm pandoc-2.17.0.1-1-amd64.deb \
   && . /etc/environment \
   && install2.r --error \
     --repos 'https://cloud.r-project.org' \


### PR DESCRIPTION
Version updates include
* rocker/r-ver:4.1.2 and all subsequent images
* Anaconda 2021.11
* pandoc 2.17.0.1

Remove repo reference in R package installations (otherwise the Dockerfile can't seem to find the source reference).

gitignore now includes .vscode/